### PR TITLE
Removed "waiting one year" for movie without ETA

### DIFF
--- a/couchpotato/core/media/movie/searcher/main.py
+++ b/couchpotato/core/media/movie/searcher/main.py
@@ -280,7 +280,7 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
         now = int(time.time())
         now_year = date.today().year
 
-        if (year is None or year < now_year - 1) and (not dates or (dates.get('theater', 0) == 0 and dates.get('dvd', 0) == 0)):
+        if (not dates or (dates.get('theater', 0) == 0 and dates.get('dvd', 0) == 0)):
             return True
         else:
 


### PR DESCRIPTION
Why we should wait one year before searching for a movie without ETA information at all ?
For example, "9 mois ferme" is already released !

I know there is an option to completely deactivate ETA verification but I still want this feature for movies with ETA informations.
